### PR TITLE
Updates script to check out DMG cookbook

### DIFF
--- a/app/views/soloist_scripts/show.sh.erb
+++ b/app/views/soloist_scripts/show.sh.erb
@@ -32,5 +32,10 @@ if [[ -d pivotal_workstation ]]; then
 else
   git clone https://github.com/pivotal/pivotal_workstation.git
 fi
+if [[ -d dmg ]]; then
+  cd dmg && git pull && cd ..
+else
+  git clone https://github.com/opscode-cookbooks/dmg.git
+fi
 soloist
 popd

--- a/spec/controllers/soloist_scripts_controller_spec.rb
+++ b/spec/controllers/soloist_scripts_controller_spec.rb
@@ -113,6 +113,11 @@ describe SoloistScriptsController do
           response.body.should include("- pivotal_workstation::abc")
           response.body.should include("- pivotal_workstation::def")
         end
+
+        it "should checkout the dmg cookbook" do
+          get :show, :id => @soloist_script, :format => :sh
+          response.body.should include("git clone https://github.com/opscode-cookbooks/dmg.git")
+        end
       end
     end
 


### PR DESCRIPTION
Pivotal Workstation is using the dmg cookbook directly now.

We pushed this change this afternoon then realized it breaks solo_wizard.

In the long term (well, starting now) we're thinking about using librarian for this, but haven't worked out the details.
