### PR TITLE
Check for rbenv in addition to rvm when installing soloist to avoid sudo

### DIFF
--- a/app/views/soloist_scripts/show.sh.erb
+++ b/app/views/soloist_scripts/show.sh.erb
@@ -12,7 +12,7 @@
 # This script may be freely distributed under the MIT license.
 
 pushd `pwd`
-if rvm --version 2>/dev/null; then
+if rvm --version 2>/dev/null || rbenv 2>/dev/null; then
   gem install soloist
 else
   sudo gem install soloist


### PR DESCRIPTION
First of all, great app! I'm a big fan. I ran into an issue running the script on an rbenv box and wanted to add in a line to check for rbenv just like the rvm line that was already in place.  Test suite passed before and after the change.  Thanks!
