### PR TITLE
clickable checkbox labels

### DIFF
--- a/app/views/soloist_scripts/_form.html.haml
+++ b/app/views/soloist_scripts/_form.html.haml
@@ -12,8 +12,9 @@
           %fieldset.recipe-selector
             - recipe_group.recipes.each do |recipe|
               .recipe-pair
-                = check_box_tag :recipe_ids, recipe.id, @soloist_script.recipes.include?(recipe), :name => 'soloist_script[recipe_ids][]'
-                = label_tag :recipe_ids, recipe.name
+                %label
+                  = check_box_tag :recipe_ids, recipe.id, @soloist_script.recipes.include?(recipe), :name => 'soloist_script[recipe_ids][]'
+                  = recipe.name
                 = link_to "view details", "#", :class => "recipe-details",
                   :data => { :details => { :title => recipe_details_title(recipe), :description => recipe_details_description(recipe) } }
 


### PR DESCRIPTION
The way solowizard.com works currently, clicking the label text of any checkbox, checks the first checkbox in the list. This fix wraps each checkbox in a label and puts an implied clickable label on the enclosed checkbox.

I love solowizard.com, just making it a bit easier to use :)
